### PR TITLE
add XJoy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ TODO
 * [hactool](https://github.com/SciresM/hactool)
 * [switch\_decrypt](https://github.com/MCMrARM/switch_decrypt)
 * [switchfs](https://github.com/ihaveamac/switchfs)
+* [XJoy (use Joy-Cons as a virtual Xbox 360 controller in PC games)](https://github.com/sam0x17/XJoy)
 
 ## Other OS
 ### Linux


### PR DESCRIPTION
Adds a link to XJoy which is an open source tool that uses ViGEm and hidapi to allow a pair of Joy-Cons to be used in windows video games as a virtual Xbox 360 controller.